### PR TITLE
Multithreaded networking

### DIFF
--- a/on_restart.sh
+++ b/on_restart.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Script to run on each machine bootup
+
+# Unmount the default disk
+sudo umount /dev/sdb1
+# Change the default scheduler so writes get merged at the backup
+echo 'mq-deadline' | sudo tee -a /sys/block/sdb/queue/scheduler

--- a/src/README.md
+++ b/src/README.md
@@ -325,6 +325,11 @@ ssh-add ~/.ssh/id_rsa
 ```
 Then follow the instructions outputted by [launch.sh](launch.sh) to SSH into the VM and launch rollbaccine.
 
+On each machine restart, run the following script:
+```bash
+./on_restart.sh
+```
+
 When you're done with the VMs, delete them, replacing `rollbaccine` with the name you used above:
 ```bash
 ./cleanup -n rollbaccine

--- a/src/rollbaccine.c
+++ b/src/rollbaccine.c
@@ -1055,7 +1055,10 @@ static int rollbaccine_map(struct dm_target *ti, struct bio *bio) {
                 bio_data->shallow_clone->bi_end_io = leader_write_disk_end_io;
 
                 // Set shared data between clones
-                atomic_set(&bio_data->ref_counter, 2);
+                // atomic_set(&bio_data->ref_counter, 2);
+                // TODO: Temp remove networking
+                atomic_set(&bio_data->ref_counter, 1);
+                // TODO: Temp remove networking
                 bio_data->deep_clone->bi_private = bio_data;
                 bio_data->shallow_clone->bi_private = bio_data;
 
@@ -1092,8 +1095,9 @@ static int rollbaccine_map(struct dm_target *ti, struct bio *bio) {
                     print_and_update_latency("leader_process_write: submit", &time);
                 }
 
-                INIT_WORK(&bio_data->broadcast_work, broadcast_bio);
-                queue_work(device->broadcast_bio_queue, &bio_data->broadcast_work);
+                // TODO: Temp remove networking
+                // INIT_WORK(&bio_data->broadcast_work, broadcast_bio);
+                // queue_work(device->broadcast_bio_queue, &bio_data->broadcast_work);
                 break;
             case READ:
                 // Create the disk clone. Necessary because we change the bi_end_io function, so we can't submit the original.

--- a/src/rollbaccine.c
+++ b/src/rollbaccine.c
@@ -998,14 +998,14 @@ static int rollbaccine_map(struct dm_target *ti, struct bio *bio) {
                 bio_data->deep_clone = deep_bio_clone(device, bio);
                 if (!bio_data->deep_clone) {
                     printk(KERN_ERR "Could not create deep clone");
-                    return;
+                    return DM_MAPIO_REMAPPED;
                 }
 
                 // Create the disk clone. Necessary because we change the bi_end_io function, so we can't submit the original.
                 bio_data->shallow_clone = shallow_bio_clone(device, bio_data->deep_clone);
                 if (!bio_data->shallow_clone) {
                     printk(KERN_ERR "Could not create shallow clone");
-                    return;
+                    return DM_MAPIO_REMAPPED;
                 }
                 // Set end_io so once this write completes, queued writes can be unblocked
                 bio_data->shallow_clone->bi_end_io = leader_write_disk_end_io;

--- a/src/rollbaccine.c
+++ b/src/rollbaccine.c
@@ -1055,10 +1055,7 @@ static int rollbaccine_map(struct dm_target *ti, struct bio *bio) {
                 bio_data->shallow_clone->bi_end_io = leader_write_disk_end_io;
 
                 // Set shared data between clones
-                // atomic_set(&bio_data->ref_counter, 2);
-                // TODO: Temp remove networking
-                atomic_set(&bio_data->ref_counter, 1);
-                // TODO: Temp remove networking
+                atomic_set(&bio_data->ref_counter, 2);
                 bio_data->deep_clone->bi_private = bio_data;
                 bio_data->shallow_clone->bi_private = bio_data;
 
@@ -1095,9 +1092,8 @@ static int rollbaccine_map(struct dm_target *ti, struct bio *bio) {
                     print_and_update_latency("leader_process_write: submit", &time);
                 }
 
-                // TODO: Temp remove networking
-                // INIT_WORK(&bio_data->broadcast_work, broadcast_bio);
-                // queue_work(device->broadcast_bio_queue, &bio_data->broadcast_work);
+                INIT_WORK(&bio_data->broadcast_work, broadcast_bio);
+                queue_work(device->broadcast_bio_queue, &bio_data->broadcast_work);
                 break;
             case READ:
                 // Create the disk clone. Necessary because we change the bi_end_io function, so we can't submit the original.

--- a/src/rollbaccine.c
+++ b/src/rollbaccine.c
@@ -148,6 +148,10 @@ struct rollbaccine_device {
 
     // Workqueue to submit pending bios because bio_endio can't submit work (because it might sleep)
     struct workqueue_struct *submit_bio_queue;
+    // Workqueue to execute encryption, broadcasting, etc for leaders so writes aren't restricted to a few specific cores
+    struct workqueue_struct *leader_write_queue;
+    // To ensure that at most 1 message is being broadcasted by each thread
+    struct mutex __percpu *broadcast_mutex;
 
     // Sockets, tracked so we can kill them on exit.
     struct list_head server_sockets;
@@ -259,7 +263,9 @@ void network_end_io(struct bio * deep_clone);
 void broadcast_bio(struct bio_data* bio_data);
 struct bio *shallow_bio_clone(struct rollbaccine_device * device, struct bio * bio_src);
 struct bio *deep_bio_clone(struct rollbaccine_device * device, struct bio * bio_src);
-bool verify_msg(struct rollbaccine_device *device, struct multithreaded_socket_list *multithreaded_socket_list, char *msg, size_t msg_size, char *expected_hash, uint64_t sender_id, uint64_t sender_thread, uint64_t msg_index);
+void leader_process_write(struct work_struct *work);
+bool verify_msg(struct rollbaccine_device *device, struct multithreaded_socket_list *multithreaded_socket_list, char *msg, size_t msg_size,
+                                                                    char *expected_hash, uint64_t sender_id, uint64_t sender_thread, uint64_t msg_index);
 void hash_buffer(struct rollbaccine_device *device, char *buffer, size_t len, char *out);
 // Returns array of checksums and IVs for writes, NULL for reads
 unsigned char *enc_or_dec_bio(struct bio_data * bio_data, enum EncDecType type);
@@ -514,6 +520,8 @@ void atomic_max(atomic_t *old, int new) {
 }
 
 void block_if_not_enough_memory(struct rollbaccine_device *device, int num_pages_needed) {
+    // TODO: Don't restrict memory for now
+    return;
     unsigned long flags;
     if (num_pages_needed > device->max_memory_pages) {
         printk_ratelimited(KERN_ERR "Write requires more memory than max pages allocated: %d, automatically allowing write through", num_pages_needed);
@@ -527,6 +535,8 @@ void block_if_not_enough_memory(struct rollbaccine_device *device, int num_pages
 }
 
 void release_memory(struct rollbaccine_device *device, int num_pages_released) {
+    // TODO: Don't restrict memory for now
+    return;
     unsigned long flags;
     if (num_pages_released > 0) {
         spin_lock_irqsave(&device->memory_wait_queue.lock, flags);
@@ -751,12 +761,14 @@ void broadcast_bio(struct bio_data *clone_bio_data) {
     struct bio_vec bvec, chunked_bvec;
     struct bvec_iter iter;
     struct socket *sock;
+    struct mutex *broadcast_mutex;
     unsigned long flags;
     cycles_t time = get_cycles_if_flag_on();
     cycles_t total_time = get_cycles_if_flag_on();
 
     // Pin this to a specific CPU
     set_cpus_allowed_ptr(current, cpumask_of(smp_processor_id()));
+    broadcast_mutex = this_cpu_ptr(device->broadcast_mutex);
 
     metadata.type = clone_bio_data->is_fsync ? ROLLBACCINE_FSYNC : ROLLBACCINE_WRITE;
     metadata.bal = device->bal;
@@ -791,7 +803,9 @@ void broadcast_bio(struct bio_data *clone_bio_data) {
         memcpy(additional_hash_msg->checksum_and_iv, checksum_and_iv + ROLLBACCINE_METADATA_CHECKSUM_IV_SIZE, remaining_checksum_and_iv_size);
     }
 
-    // TODO: Need additional per-cpu lock
+    // First lock to prevent the same core from broadcasting multiple messages concurrently
+    mutex_lock(broadcast_mutex);
+    // Second lock to make sure the list of connected sockets hasn't changed
     percpu_down_read(&device->connected_sockets_sem);
     list_for_each_entry_safe(multithreaded_socket_list, next_multithreaded_socket_list, &device->connected_sockets, list) {
         sock = this_cpu_read(*multithreaded_socket_list->socks);
@@ -864,6 +878,7 @@ void broadcast_bio(struct bio_data *clone_bio_data) {
     }
     // printk(KERN_INFO "Sent metadata message and bios, sector: %llu, num pages: %llu", metadata.sector, metadata.num_pages);
     percpu_up_read(&device->connected_sockets_sem);
+    mutex_unlock(broadcast_mutex);
 
     if (additional_hash_msg != NULL) {
         kfree(additional_hash_msg);
@@ -926,13 +941,88 @@ struct bio *deep_bio_clone(struct rollbaccine_device *device, struct bio *bio_sr
     return clone;
 }
 
+void leader_process_write(struct work_struct *work) {
+    struct bio_data *bio_data = container_of(work, struct bio_data, broadcast_work);
+    struct rollbaccine_device *device = bio_data->device;
+    struct bio *bio = bio_data->bio_src;
+    bool doesnt_conflict_with_other_writes = true;
+    cycles_t time = get_cycles_if_flag_on();
+    unsigned long flags;
+
+    // Wait until there's enough memory. Ask for 2 pages per page since we're deep cloning
+    block_if_not_enough_memory(device, bio_sectors(bio) * 2 / SECTORS_PER_PAGE);
+
+    bio_data->is_fsync = requires_fsync(bio);
+    // NOTE: Removing the flags causes Azure to crash, so we'll keep them for now
+    // bio->bi_opf = remove_fsync_flags(bio->bi_opf);  // All fsyncs become logical fsyncs
+
+    // Encrypt
+    bio_data->checksum_and_iv = enc_or_dec_bio(bio_data, ROLLBACCINE_ENCRYPT);
+    print_and_update_latency("leader_process_write: encryption", &time);
+
+    // Create the network clone
+    bio_data->deep_clone = deep_bio_clone(device, bio);
+    if (!bio_data->deep_clone) {
+        printk(KERN_ERR "Could not create deep clone");
+        return;
+    }
+
+    // Create the disk clone. Necessary because we change the bi_end_io function, so we can't submit the original.
+    bio_data->shallow_clone = shallow_bio_clone(device, bio_data->deep_clone);
+    if (!bio_data->shallow_clone) {
+        printk(KERN_ERR "Could not create shallow clone");
+        return;
+    }
+    // Set end_io so once this write completes, queued writes can be unblocked
+    bio_data->shallow_clone->bi_end_io = leader_write_disk_end_io;
+
+    // Set shared data between clones
+    atomic_set(&bio_data->ref_counter, 2);
+    bio_data->deep_clone->bi_private = bio_data;
+    bio_data->shallow_clone->bi_private = bio_data;
+
+    // Increment indices, place ops on queue, submit cloned ops to disk
+    spin_lock_irqsave(&device->index_lock, flags);
+    print_and_update_latency("leader_process_write: encryption -> obtained index lock", &time);
+    // Increment write index
+    bio_data->write_index = ++device->write_index;
+    doesnt_conflict_with_other_writes = try_insert_into_outstanding_ops(device, bio_data, true);
+    if (!doesnt_conflict_with_other_writes) {
+        add_to_pending_ops_tail(device, bio_data);
+    }
+    // printk(KERN_INFO "Inserted clone %p, write index: %d", bio_data->shallow_clone, bio_data->write_index);
+    if (bio_data->is_fsync) {
+        // Add original bio to fsyncs blocked on replication
+        bio->bi_private = bio_data->write_index;  // HACK: Store the write index in this fsync's bi_private field so it can be checked when network fsyncs are being acknowledged
+        spin_lock(&device->replica_fsync_lock);
+        print_and_update_latency("leader_process_write: index lock -> obtained replica fsync lock", &time);
+        bio_list_add(&device->fsyncs_pending_replication, bio);
+#ifdef MEMORY_TRACKING
+        device->num_fsyncs_pending_replication += 1;
+#endif
+        spin_unlock(&device->replica_fsync_lock);
+    }
+    spin_unlock_irqrestore(&device->index_lock, flags);
+
+    // Even though submit order != write index order, any conflicting writes will only be submitted later so any concurrency here is fine
+    if (doesnt_conflict_with_other_writes) {
+        if (bio_data->checksum_and_iv != NULL) {
+            update_global_checksum_and_iv(device, bio_data->checksum_and_iv, bio_data->start_sector, bio_data->end_sector - bio_data->start_sector);
+        }
+        submit_bio_noacct(bio_data->shallow_clone);
+        this_cpu_inc(num_ops_on_cpu);
+        print_and_update_latency("leader_process_write: submit", &time);
+    }
+
+    broadcast_bio(bio_data);
+}
+
 static int rollbaccine_map(struct dm_target *ti, struct bio *bio) {
     bool is_cloned = false;
     bool doesnt_conflict_with_other_writes = true;
     struct rollbaccine_device *device = ti->private;
     struct bio_data *bio_data;
     cycles_t total_time = get_cycles_if_flag_on();
-    cycles_t time = get_cycles_if_flag_on();
     unsigned long flags;
 
     bio_set_dev(bio, device->dev->bdev);
@@ -950,72 +1040,9 @@ static int rollbaccine_map(struct dm_target *ti, struct bio *bio) {
         
         switch (bio_data_dir(bio)) {
             case WRITE:
-                // Wait until there's enough memory. Ask for 2 pages per page since we're deep cloning
-                block_if_not_enough_memory(device, bio_sectors(bio) * 2 / SECTORS_PER_PAGE);
-
-                bio_data->is_fsync = requires_fsync(bio);
-                // NOTE: Removing the flags causes Azure to crash, so we'll keep them for now
-                // bio->bi_opf = remove_fsync_flags(bio->bi_opf);  // All fsyncs become logical fsyncs
-
-                // Encrypt
-                bio_data->checksum_and_iv = enc_or_dec_bio(bio_data, ROLLBACCINE_ENCRYPT);
-                print_and_update_latency("rollbaccine_map: encryption", &time);
-
-                // Create the network clone
-                bio_data->deep_clone = deep_bio_clone(device, bio);
-                if (!bio_data->deep_clone) {
-                    printk(KERN_ERR "Could not create deep clone");
-                    return DM_MAPIO_REMAPPED;
-                }
-
-                // Create the disk clone. Necessary because we change the bi_end_io function, so we can't submit the original.
-                bio_data->shallow_clone = shallow_bio_clone(device, bio_data->deep_clone);
-                if (!bio_data->shallow_clone) {
-                    printk(KERN_ERR "Could not create shallow clone");
-                    return DM_MAPIO_REMAPPED;
-                }
-                // Set end_io so once this write completes, queued writes can be unblocked
-                bio_data->shallow_clone->bi_end_io = leader_write_disk_end_io;
-
-                // Set shared data between clones
-                atomic_set(&bio_data->ref_counter, 2);
-                bio_data->deep_clone->bi_private = bio_data;
-                bio_data->shallow_clone->bi_private = bio_data;
-
-                // Increment indices, place ops on queue, submit cloned ops to disk
-                spin_lock_irqsave(&device->index_lock, flags);
-                print_and_update_latency("rollbaccine_map: encryption -> obtained index lock", &time);
-                // Increment write index
-                bio_data->write_index = ++device->write_index;
-                doesnt_conflict_with_other_writes = try_insert_into_outstanding_ops(device, bio_data, true);
-                if (!doesnt_conflict_with_other_writes) {
-                    add_to_pending_ops_tail(device, bio_data);
-                }
-                // printk(KERN_INFO "Inserted clone %p, write index: %d", bio_data->shallow_clone, bio_data->write_index);
-                if (bio_data->is_fsync) {
-                    // Add original bio to fsyncs blocked on replication
-                    bio->bi_private = bio_data->write_index;  // HACK: Store the write index in this fsync's bi_private field so it can be checked when network fsyncs are being acknowledged
-                    spin_lock(&device->replica_fsync_lock);
-                    print_and_update_latency("rollbaccine_map: index lock -> obtained replica fsync lock", &time);
-                    bio_list_add(&device->fsyncs_pending_replication, bio);
-#ifdef MEMORY_TRACKING
-                    device->num_fsyncs_pending_replication += 1;
-#endif
-                    spin_unlock(&device->replica_fsync_lock);
-                }
-                spin_unlock_irqrestore(&device->index_lock, flags);
-
-                // Even though submit order != write index order, any conflicting writes will only be submitted later so any concurrency here is fine
-                if (doesnt_conflict_with_other_writes) {
-                    if (bio_data->checksum_and_iv != NULL) {
-                        update_global_checksum_and_iv(device, bio_data->checksum_and_iv, bio_data->start_sector, bio_data->end_sector - bio_data->start_sector);
-                    }
-                    submit_bio_noacct(bio_data->shallow_clone);
-                    this_cpu_inc(num_ops_on_cpu);
-                    print_and_update_latency("rollbaccine_map: submit", &time);
-                }
-
-                broadcast_bio(bio_data);
+                // Send to workqueue so it'll do the CPU load balancing for us
+                INIT_WORK(&bio_data->broadcast_work, leader_process_write);
+                queue_work(device->leader_write_queue, &bio_data->broadcast_work);
                 break;
             case READ:
                 // Create the disk clone. Necessary because we change the bi_end_io function, so we can't submit the original.
@@ -1923,10 +1950,21 @@ static int rollbaccine_constructor(struct dm_target *ti, unsigned int argc, char
     device->shutting_down = false;
     percpu_init_rwsem(&device->connected_sockets_sem);
 
-    device->submit_bio_queue = alloc_workqueue("submit bio queue", 0, 0);
+    device->submit_bio_queue = alloc_workqueue("submit bio queue", WQ_UNBOUND, 0);
     if (!device->submit_bio_queue) {
         printk(KERN_ERR "Cannot allocate submit bio queue");
         return -ENOMEM;
+    }
+
+    device->leader_write_queue = alloc_workqueue("leader write queue", WQ_UNBOUND, 0);
+    if (!device->leader_write_queue) {
+        printk(KERN_ERR "Cannot allocate leader write queue");
+        return -ENOMEM;
+    }
+
+    device->broadcast_mutex = alloc_percpu(struct mutex);
+    for_each_online_cpu(cpu_id) {
+        mutex_init(per_cpu_ptr(device->broadcast_mutex, cpu_id));
     }
 
     // Get the device from argv[0] and store it in device->dev
@@ -2135,10 +2173,12 @@ static void rollbaccine_destructor(struct dm_target *ti) {
     free_percpu(device->hash_desc);
 
     kvfree(device->checksums);
+    free_percpu(device->broadcast_mutex);
     crypto_free_aead(device->tfm);
     crypto_free_shash(device->hash_alg);
     percpu_free_rwsem(&device->connected_sockets_sem);
     // Note: I'm not sure how to free theses queues which may have outstanding bios. Hopefully nothing breaks horribly
+    destroy_workqueue(device->leader_write_queue);
     destroy_workqueue(device->submit_bio_queue);
     dm_put_device(ti, device->dev);
     bioset_exit(&device->bs);

--- a/src/rollbaccine.c
+++ b/src/rollbaccine.c
@@ -1653,7 +1653,6 @@ void blocking_read(struct rollbaccine_device *device, struct multisocket *multis
         else if (bio_distance > ROLLBACCINE_AVG_WRITES_OUT_OF_ORDER) {
             // This bio does not fit on the pending bio ring. This is a BIG problem. Likely the leader is too slow or its messages are maliciously being dropped.
             printk(KERN_ERR "Pending bio ring overflowing, bio distance: %d", bio_distance);
-            free_pages_end_io(received_bio);
             alert_client_of_liveness_problem(device, multisocket);
             goto disconnect_from_sender;
         }

--- a/src/rollbaccine.c
+++ b/src/rollbaccine.c
@@ -37,7 +37,7 @@
 #define KEY_SIZE 16
 #define ROLLBACCINE_AVG_HASHES_PER_WRITE 4
 #define ROLLBACCINE_METADATA_CHECKSUM_IV_SIZE (AES_GCM_AUTH_SIZE + AES_GCM_IV_SIZE) * ROLLBACCINE_AVG_HASHES_PER_WRITE
-#define ROLLBACCINE_PENDING_BIO_RING_SIZE 100 // Max "hole" between writes
+#define ROLLBACCINE_PENDING_BIO_RING_SIZE 1000000 // Max "hole" between writes
 #define SHA256_SIZE 32
 #define NUM_NICS 4 // Number of sockets we should use for networking to maximize bandwidth
 #define MODULE_NAME "rollbaccine"


### PR DESCRIPTION
Does not actually improve throughput or latency, although it does not blow up memory and reduces the amount of time it takes for fio to "end" (I'm assuming for the writes buffered in map() to actually go to disk) compared to the single-threaded implementation.

I suspect the reason this does not perform better is because when work is moved across CPU cores, it triggers cache misses.